### PR TITLE
Hotfix autolibcflags.py fix installation of plugin for linux

### DIFF
--- a/autolibcflags.py
+++ b/autolibcflags.py
@@ -58,7 +58,7 @@ class AutoLibcFlags(idaapi.plugin_t):
             self.enum_cache = os.path.join(os.environ['APPDATA'], 'IdaAutoLibcFlags')
             self.os = 'win'
         elif platform.system() == 'Linux':
-            self.enum_cache == os.path.join(os.environ['HOME'] ,".cache/IdaAutoLibcFlags")
+            self.enum_cache == os.path.join(os.environ['HOME'] ,".idalibcflags")
             self.os = 'linux'
         else:
             print('[IDAAutoLibcFlags] Unknown operating system | Not supported')

--- a/autolibcflags.py
+++ b/autolibcflags.py
@@ -58,7 +58,7 @@ class AutoLibcFlags(idaapi.plugin_t):
             self.enum_cache = os.path.join(os.environ['APPDATA'], 'IdaAutoLibcFlags')
             self.os = 'win'
         elif platform.system() == 'Linux':
-            self.enum_cache == os.path.join(os.environ['HOME'] ,".idalibcflags")
+            self.enum_cache = os.path.join(os.environ['HOME'] ,".idalibcflags")
             self.os = 'linux'
         else:
             print('[IDAAutoLibcFlags] Unknown operating system | Not supported')


### PR DESCRIPTION
Fix 2 problem when using the plugin for Linux
1. Mistyped == instead of =
2. Incorrect cache place

tested on IDA 8.4 Ubuntu 22.04LTS